### PR TITLE
Enable all NVIDIA Driver Capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -281,7 +281,7 @@ RUN if id -u 1000 >/dev/null 2>&1; then userdel --force --remove $(getent passwd
 RUN echo "source /.version_information.sh" >> ~/.bashrc
 COPY .version_information.sh /.version_information.sh
 
-# nvidia support
+# enable all GPU capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -281,6 +281,10 @@ RUN if id -u 1000 >/dev/null 2>&1; then userdel --force --remove $(getent passwd
 RUN echo "source /.version_information.sh" >> ~/.bashrc
 COPY .version_information.sh /.version_information.sh
 
+# nvidia support
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+
 # container startup setup
 ENV WORKSPACE=/docker-ros/ws
 WORKDIR $WORKSPACE


### PR DESCRIPTION
Allows you to use the GPU for RViz for example.

Previously, env variables of, e.g., `rwthika/ros2-cuda:jazzy` were set to:
- `NVIDIA_VISIBLE_DEVICES=all`
- `NVIDIA_DRIVER_CAPABILITIES=compute,utility`